### PR TITLE
fix: return full booking object on create and resolve failing service. all tests pass. 

### DIFF
--- a/bookings/serializers.py
+++ b/bookings/serializers.py
@@ -55,8 +55,8 @@ class BookingCreateSerializer(serializers.ModelSerializer):
         # Deduct one session from the service
         service.remaining_sessions -= 1
         if service.remaining_sessions == 0:
-            service.is_available == False
-        service.save()
+            service.is_available = False
+        service.save(update_fields=["remaining_sessions", "is_available"])
 
         #create a booking
         booking = Booking.objects.create(
@@ -70,7 +70,7 @@ class BookingCreateSerializer(serializers.ModelSerializer):
 
         return booking
 
-class BookingRatingReviewSerializer(serializers.Serializer):
+class BookingRatingReviewSerializer(serializers.ModelSerializer):
     class Meta:
         model = Booking
         fields = ['customer_rating', 'customer_review']

--- a/bookings/views.py
+++ b/bookings/views.py
@@ -65,14 +65,14 @@ class BookingListCreateView(GenericAPIView):
         # print("serializer.data", serializer.data)
         return Response(serializer.data)
     
-    #only customer is allowed to create a booking
+    # only customer is allowed to create a booking
     def post(self, request):
         serializer = self.get_serializer(data=request.data)
-        if serializer.is_valid():
-            serializer.save()
-            return Response(serializer.data, status=status.HTTP_201_CREATED)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-           
+        serializer.is_valid(raise_exception=True)
+        booking = serializer.save()
+        # return the full booking data
+        output = BookingSerializer(booking, context={'request': request}).data
+        return Response(output, status=status.HTTP_201_CREATED)
 
 # GET/PATCH
 # /bookings/<booking_id>

--- a/services/serializers.py
+++ b/services/serializers.py
@@ -7,6 +7,8 @@ class ServiceSerializer(serializers.ModelSerializer):
     longitude = serializers.FloatField(source='owner.longitude', read_only=True)
     city=serializers.CharField(source='owner.city', read_only=True)
     zip_code=serializers.CharField(source='owner.zip_code', read_only=True)
+    credit_required = serializers.IntegerField(min_value=1)
+    total_sessions = serializers.IntegerField(min_value=1)
 
     customer_reviews = serializers.ListField(
         child=serializers.CharField(),

--- a/services/serializers.py
+++ b/services/serializers.py
@@ -7,7 +7,7 @@ class ServiceSerializer(serializers.ModelSerializer):
     longitude = serializers.FloatField(source='owner.longitude', read_only=True)
     city=serializers.CharField(source='owner.city', read_only=True)
     zip_code=serializers.CharField(source='owner.zip_code', read_only=True)
-    credit_required = serializers.IntegerField(min_value=1)
+    credit_required = serializers.IntegerField(min_value=0.5)
     total_sessions = serializers.IntegerField(min_value=1)
 
     customer_reviews = serializers.ListField(

--- a/services/views.py
+++ b/services/views.py
@@ -15,16 +15,12 @@ class ServiceListCreateView(APIView):
     serializer_class = ServiceSerializer
 
     def get(self, request):
-        # allows users to view a list of services created by themsevles
+        # allows users to view a list of services created by themselves
         owner_id = request.query_params.get('owner_id')
-        # zip_code = request.query_params.get('zip_code')
         queryset = Service.objects.all()
         if owner_id:
             queryset = queryset.filter(owner_id=owner_id)
-        # allow users to view services provided by others (but not themselves)
-        else:
-            queryset = queryset.exclude(owner_id=request.user.id)
-        
+
         serializer = self.serializer_class(queryset, many=True)
         return Response(serializer.data)
 

--- a/services/views.py
+++ b/services/views.py
@@ -20,7 +20,10 @@ class ServiceListCreateView(APIView):
         queryset = Service.objects.all()
         if owner_id:
             queryset = queryset.filter(owner_id=owner_id)
-
+        # allow users to view services provided by others (but not themselves)
+        else:
+            queryset = queryset.exclude(owner_id=request.user.id)
+            
         serializer = self.serializer_class(queryset, many=True)
         return Response(serializer.data)
 


### PR DESCRIPTION
- When a new booking is created, return 201 status and the new instance in the response body
- Adjusted service endpoints to resolve test failures
- All tests passing 
